### PR TITLE
Allow for numerical entity ids

### DIFF
--- a/lib/entity.js
+++ b/lib/entity.js
@@ -417,7 +417,7 @@ function resolve_id_query( qin, ent ) {
   {
     q = {id:ent.id}
   }
-  else if( _.isString(qin) ) {
+  else if( _.isString(qin) || _.isNumber(qin) ) {
     q = '' === qin ? null : {id:qin}
   }
   else if( _.isFunction(qin) ) {


### PR DESCRIPTION
`foo.load$(numerical_id)` didn't allow for numerical ids, causing errors in seneca-mysql-store (`args.q` in the `load` method has unexpected content and constructed query would be wrong)

@rjrodger numerical ids have other corner cases I would like to discuss with you.