### PR TITLE
seneca.ready(): fixed 2nd callback argument to be seneca (resolves #82)

### DIFF
--- a/lib/seneca.js
+++ b/lib/seneca.js
@@ -1076,7 +1076,9 @@ function make_seneca(initial_options ) {
     var self = this
 
     if( _.isFunction(ready) ) {
-      self.once('ready',ready)
+      self.once('ready',function(err) {
+          ready.call(self, err, !err && self);
+      });
       if( !private$.wait_for_ready ) {
         private$.wait_for_ready = true
         self.act('role:seneca,ready:true,gate$:true')


### PR DESCRIPTION
See https://github.com/rjrodger/seneca/issues/82