### PR TITLE
minor discovery improvement

### DIFF
--- a/package.json
+++ b/package.json
@@ -4,6 +4,13 @@
   "keywords": [
     "micro",
     "service",
+    "microservice",
+    "micro-service",
+    "microservices",
+    "micro-services",
+    "services",
+    "micro services",
+    "micro service",
     "framework",
     "minimum",
     "viable",


### PR DESCRIPTION
we want seneca to be at the top of the first page on npm searches, 
different people search differently : "micro service" "microservice" "micro-service"