### PR TITLE
bugfix - latest v8 strict mode enforcements

### DIFF
--- a/lib/logging.js
+++ b/lib/logging.js
@@ -225,7 +225,7 @@ var makelogroute = exports.makelogroute = function(entry,logrouter) {
     var routestr = util.inspect(route)
 
     var handler = entry.handler
-    if( handler ) {
+    if( handler && handler instanceof Object) {
       handler.routestr = routestr
     }
 


### PR DESCRIPTION
strict mode doesn't allow the setting of read only property, this is enforced in later v8
when the handler variable is a string, setting handler.routestr will throw a TypeError in
later v8 implementations (e.g. io.js). 

Checking that handler is instanceof Object covers functions arrays objects etc, but excludes string and number primitives