### PR TITLE
Restore the behaviour of this.prior to allow for extending 

### DIFF
--- a/docpad/src/documents/getting-started.html.md.eco
+++ b/docpad/src/documents/getting-started.html.md.eco
@@ -555,7 +555,10 @@ seneca
 
 The Seneca instance provided to an action function via the the `this`
 context variable has a special `prior` method that calls the previous
-action definition for the current action pattern. The prior function has parameters:
+action definition for the current action pattern, or the next action
+that matches the pattern.
+
+The prior function has parameters:
 
    * `msg`: the msg object, which you may have modified
    * `response_callback`: a callback function, where you may modify the result

--- a/seneca.js
+++ b/seneca.js
@@ -1041,11 +1041,6 @@ function make_seneca( initial_options ) {
     var priormeta = self.find( pattern )
 
 
-    if( priormeta && priormeta.pattern !== actmeta.pattern ) {
-      priormeta = null
-    }
-
-
     if( priormeta ) {
       if( _.isFunction(priormeta.handle) ) {
         priormeta.handle(action)


### PR DESCRIPTION
Before 0.6.2 `this.prior()` would call the next matching pattern, if there were no more exact pattern matches. This was relied on by a lot of real-world code that i've seen, including seneca-elasticsearch.
The relevant issue is #130.

One place where it seems to be used a lot is extending entity actions with ones that are more specific. So
`role:entity,cmd:save,name:foo` would use this.prior to call the data store accessed by `role:entity,cmd:save` actions.

This PR restores the previous functionality, writes a test to define it, and updates the documentation to match the behaviour. We should probably put out a working 0.6.4 release with this fix, and then we can discuss a way to change the behavior for 0.7.x (if that's what we actually want).

