### PR TITLE
Move async to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,6 @@
   ],
   "dependencies": {
     "archy": "1.0.0",
-    "async": "0.9.2",
     "eraro": "0.4.1",
     "gate-executor": "0.2.3",
     "gex": "0.2.0",
@@ -74,6 +73,7 @@
     "build": "./build.sh"
   },
   "devDependencies": {
+    "async": "0.9.2",
     "body-parser": "1.11.0",
     "connect": "3.0.2",
     "connect-query": "0.2.0",


### PR DESCRIPTION
`async` is only used for testing, moving to devDependencies.