### PR TITLE
Expose the Entity object for third-party extensions (Fixes issue 26)

### DIFF
--- a/seneca.js
+++ b/seneca.js
@@ -2321,6 +2321,8 @@ function make_seneca( initial_options ) {
     }
   })
 
+  // Expose the Entity object so third-parties can do interesting things with it
+  private$.exports.Entity = make_entity.Entity
 
   return root
 }


### PR DESCRIPTION
This will help plugins like seneca-bluebird (https://github.com/tasinet/seneca-bluebird) integrate with seneca in an npm-native way, without having to hack the seneca source.

I'm making a corresponding PR for seneca-bluebird to update it for the new plugin function signature.

Thanks to @sc0ttyd for identifying the changes needed to get this working!