### PR TITLE
Minor refactor of cmdline

### DIFF
--- a/lib/optioner.js
+++ b/lib/optioner.js
@@ -7,8 +7,9 @@ var fs = require('fs')
 
 
 var _      = require('lodash')
-var jsonic = require('jsonic')
 var error  = require('eraro')({package:'seneca',msgmap:ERRMSGMAP()})
+var jsonic = require('jsonic')
+var minimist = require('minimist')
 
 
 var logging = require('./logging')
@@ -16,12 +17,13 @@ var common  = require('./common')
 
 
 
-module.exports = function( argv, callmodule, defaults ) {
+module.exports = function( callmodule, defaults ) {
   var DEFAULT_OPTIONS_FILE = './seneca.options.js'
   var FATAL_OPTIONS_FILE   = './options.seneca.js'
 
   var first   = true
   var options = {}
+  var argv = minimist(process.argv.slice(2))
 
   var sourcemap = {
     argv:         {},

--- a/lib/print.js
+++ b/lib/print.js
@@ -7,41 +7,37 @@ var util = require('util')
 
 
 var _        = require('lodash')
-var minimist = require('minimist')
 var archy    = require('archy')
 
 
-module.exports = function( seneca, argv ) {
-  return minimist(process.argv.slice(2))
-}
-
 /** Handle command line specific functionality */
-module.exports.handle = function( seneca, argv ) {
-  if( argv.seneca ) {
-    var cmdspec = argv.seneca
-    if( cmdspec.print ) {
-      if( !!cmdspec.print.tree ) {
+module.exports = function( seneca, argv ) {
+  if( !argv || !argv.seneca ) {
+    return;
+  }
+  var cmdspec = argv.seneca
+  if( cmdspec.print ) {
+    if( !!cmdspec.print.tree ) {
 
-        // Hack! Complex init means non-deterministic or multiple ready calls,
-        // so just delay tree print by some number of seconds to capture full tree.
-        var delay_seconds = cmdspec.print.tree.all || cmdspec.print.tree
-        if( _.isNumber( delay_seconds ) ) {
-          setTimeout(function(){
-            print_tree( seneca, cmdspec )
-          }, 1000*delay_seconds )
-        }
+      // Hack! Complex init means non-deterministic or multiple ready calls,
+      // so just delay tree print by some number of seconds to capture full tree.
+      var delay_seconds = cmdspec.print.tree.all || cmdspec.print.tree
+      if( _.isNumber( delay_seconds ) ) {
+        setTimeout(function(){
+          print_tree( seneca, cmdspec )
+        }, 1000*delay_seconds )
+      }
 
-        // Print after first ready
-        else {
-          seneca.ready(function(){
-            print_tree( this, cmdspec )
-          })
-        }
+      // Print after first ready
+      else {
+        seneca.ready(function(){
+          print_tree( this, cmdspec )
+        })
       }
-      
-      if( !!cmdspec.print.options ) {
-        seneca.options( { debug: { print: { options:true } } } )
-      }
+    }
+
+    if( !!cmdspec.print.options ) {
+      seneca.options( { debug: { print: { options:true } } } )
     }
   }
 }

--- a/seneca.js
+++ b/seneca.js
@@ -38,8 +38,8 @@ var make_entity   = require('./lib/entity')
 var store         = require('./lib/store')
 var logging       = require('./lib/logging')
 var plugin_util   = require('./lib/plugin-util')
+var print         = require('./lib/print')
 var make_optioner = require('./lib/optioner')
-var cmdline       = require('./lib/cmdline')
 var common        = require('./lib/common')
 
 
@@ -255,12 +255,10 @@ function make_seneca( initial_options ) {
   var actnid     = nid({length:5})
   var refnid     = function(){ return '('+actnid()+')' }
   var paramcheck = make_paramcheck()
-  var argv       = cmdline(root)
 
 
   // Create option resolver.
-  private$.optioner = make_optioner( 
-    argv,
+  private$.optioner = make_optioner(
     initial_options.module || module.parent || module,
     DEFAULT_OPTIONS )
 
@@ -367,7 +365,7 @@ function make_seneca( initial_options ) {
     builtin:   ''
   })
 
-  private$.actcache = ( so.actcache.active ? 
+  private$.actcache = ( so.actcache.active ?
                         lrucache({max:so.actcache.size}) :
                         {set:_.noop} )
 
@@ -474,8 +472,8 @@ function make_seneca( initial_options ) {
     }
 
     plugin.name = meta.name || plugin.name
-    plugin.tag = 
-      meta.tag || 
+    plugin.tag =
+      meta.tag ||
       plugin.tag ||
       (plugin.options && plugin.options.tag$)
 
@@ -968,11 +966,11 @@ function make_seneca( initial_options ) {
   // ### seneca.add
   // Add an message pattern and action function.
   //
-  // `seneca.add( pattern, action )`  
+  // `seneca.add( pattern, action )`
   //    * _pattern_ `o|s` &rarr; pattern definition
   //    * _action_ `f` &rarr; pattern action function
   //
-  // `seneca.add( pattern_string, pattern_object, action )`  
+  // `seneca.add( pattern_string, pattern_object, action )`
   //    * _pattern_string_ `s` &rarr; pattern definition as jsonic string
   //    * _pattern_object_ `o` &rarr; pattern definition as object
   //    * _action_ `f` &rarr; pattern action function
@@ -997,7 +995,7 @@ function make_seneca( initial_options ) {
     var actmeta   = args.actmeta || {}
 
     actmeta.plugin_name     = actmeta.plugin_name || 'root$'
-    actmeta.plugin_fullname = actmeta.plugin_fullname || 
+    actmeta.plugin_fullname = actmeta.plugin_fullname ||
       actmeta.plugin_name + (actmeta.plugin_tag ? '/' + actmeta.plugin_tag : '')
 
     var add_callpoint = callpoint()
@@ -1010,7 +1008,7 @@ function make_seneca( initial_options ) {
     // Deprecate a pattern by providing a string message using deprecate$ key.
     actmeta.deprecate = pattern.deprecate$
 
-    var strict_add = (pattern.strict$ && null != pattern.strict$.add) ? 
+    var strict_add = (pattern.strict$ && null != pattern.strict$.add) ?
           !!pattern.strict$.add : !!so.strict.add
 
     pattern = self.util.clean(args.pattern)
@@ -1525,13 +1523,13 @@ function make_seneca( initial_options ) {
 
     var id_tx = ( args.id$ || args.actid$ || instance.idgen() ).split('/')
 
-    var tx = 
+    var tx =
           id_tx[1] ||
           origargs.tx$ ||
           instance.fixedargs.tx$ ||
           instance.idgen()
 
-    var actid    = (id_tx[0] || instance.idgen()) + '/' + tx 
+    var actid    = (id_tx[0] || instance.idgen()) + '/' + tx
 
     var actstart = Date.now()
 
@@ -1565,7 +1563,7 @@ function make_seneca( initial_options ) {
                          act_callpoint )
     }
 
-    logging.log_act_in( root, {actid:actid,info:origargs.transport$}, 
+    logging.log_act_in( root, {actid:actid,info:origargs.transport$},
                         actmeta, callargs, prior_ctxt,
                         act_callpoint )
 
@@ -1605,7 +1603,7 @@ function make_seneca( initial_options ) {
           if( !( 'generate_id' === callargs.cmd ||
                  true === callargs.note ||
                  'native' === callargs.cmd ||
-                 'quickcode' === callargs.cmd 
+                 'quickcode' === callargs.cmd
                ))
           {
             err = error(
@@ -1751,9 +1749,9 @@ function make_seneca( initial_options ) {
     }
 
     // Special legacy case for seneca-perm
-    else if( err.orig && 
-             _.isString(err.orig.code) && 
-             0 === err.orig.code.indexOf('perm/') ) 
+    else if( err.orig &&
+             _.isString(err.orig.code) &&
+             0 === err.orig.code.indexOf('perm/') )
     {
       err = err.orig
       result[0] = err
@@ -2067,8 +2065,8 @@ function make_seneca( initial_options ) {
       self.log.debug( 'options', 'set', options, callpoint() )
     }
 
-    so = private$.exports.options =( (null == options) ? 
-                                     private$.optioner.get() : 
+    so = private$.exports.options =( (null == options) ?
+                                     private$.optioner.get() :
                                      private$.optioner.set( options ) )
 
     if( options && options.log ) {
@@ -2180,7 +2178,7 @@ function make_seneca( initial_options ) {
   }
 
 
-  
+
   function api_error( errhandler ) {
     this.options( {errhandler:errhandler} )
     return this
@@ -2242,7 +2240,7 @@ function make_seneca( initial_options ) {
   root.add( {role:'seneca',  ready:true},  action_seneca_ready )
   root.add( {role:'options', cmd:'get'},   action_options_get  )
 
-  cmdline.handle( root, argv )
+  print( root, private$.optioner.get().argv )
 
 
 
@@ -2601,12 +2599,12 @@ function thrower(err) {
 
 // Callpoint resolver. Indicates location in calling code.
 function make_callpoint( active ) {
-  if( active ) { 
+  if( active ) {
     return function() {
       return error.callpoint(
         new Error(),
         ['/seneca/seneca.js','/seneca/lib/', '/lodash.js'] )
-    } 
+    }
 
   } else return _.noop;
 }


### PR DESCRIPTION
* isolate the parsing of args into optioner, instead of being spread across cmdline and optioner.
* rename cmdline -> print to identify what it does after removing minimist

Options now only come from optioner.